### PR TITLE
feat: allow choosing SDK components via input parameter

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,8 +19,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup SDK
+        id: initial-setup
         uses: ./
         with:
           cache: false
       - name: Test
         run: bash -c '"${OHOS_SDK_NATIVE}/llvm/bin/clang" --version'
+      - name: Remove previous SDK installation
+        env:
+          SDK_PATH: "${{ steps.initial-setup.outputs.sdk-path }}"
+        run: bash -c 'rm -rf "${SDK_PATH}"'
+      - name: Setup SDK with Components
+        id: sdk-with-components
+        uses: ./
+        with:
+          components: "native;toolchains"
+      - name: Test
+        shell: bash
+        env:
+          SDK_PATH: "${{ steps.sdk-with-components.outputs.sdk-path }}"
+        run: |
+          ${OHOS_SDK_NATIVE}/llvm/bin/clang --version
+          ${SDK_PATH}/*/toolchains/hdc --version

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: "Whether to cache the SDK or not"
     required: false
     default: 'true'
+  components:
+    description: "Semicolon separated list of SDK components that should be made available"
+    required: false
+    default: 'native'
 outputs:
   sdk-path:
     description: "Directory of the OpenHarmony SDK"
@@ -47,6 +51,7 @@ runs:
       if: ${{ inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true' }}
       env:
         INPUT_VERSION: "${{ inputs.version }}"
+        INPUT_COMPONENTS: "${{ inputs.components }}"
     - name: Set Outputs
       id: set_outputs
       shell: bash

--- a/install_ohos_sdk.sh
+++ b/install_ohos_sdk.sh
@@ -49,10 +49,10 @@ else
     cd darwin
 fi
 
-# Todo: expose available components via an input variable.
-# For now just extract native, to save disk space
-
-unzip native-*.zip
+IFS=";" read -ra COMPONENTS <<< "${INPUT_COMPONENTS}"
+for COMPONENT in ${COMPONENTS[@]}
+do
+    echo "Extracting component ${COMPONENT}"
+    unzip ${COMPONENT}-*.zip
+done
 rm ./*.zip
-
-cd native


### PR DESCRIPTION
The `toolchains` component contains the `hap-sign-tool` which is needed for signing HAP on CI.