### PR TITLE
feat: export OHOS_NDK_HOME to env by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -77,6 +77,7 @@ runs:
         SDK_VERSION="$(jq -r .version < oh-uni-package.json )"
         API_VERSION="$(jq -r .apiVersion < oh-uni-package.json )"
         echo "OHOS_BASE_SDK_HOME=${OHOS_BASE_SDK_HOME}" >> "$GITHUB_ENV"
+        echo "OHOS_NDK_HOME=${OHOS_BASE_SDK_HOME}" >> "$GITHUB_ENV"
         echo "ohos-base-sdk-home=${OHOS_BASE_SDK_HOME}" >> "$GITHUB_OUTPUT"
         echo "OHOS_SDK_NATIVE=${OHOS_SDK_NATIVE}" >> "$GITHUB_ENV"
         echo "ohos_sdk_native=${OHOS_SDK_NATIVE}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This can help us optimize the user experience, [ohrs](https://github.com/ohos-rs) and some community adaptations use `OHOS_NDK_HOME` by default.