### PR TITLE
Prepare v0.2 for OH 5.0.1 support

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        version: [ "4.0", "4.1", "5.0"]
+        version: [ "4.0", "4.1", "5.0.0"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.2 (2024-11-29)
+
+- Bumped the default SDK version to 5.0.0
+- Do not attempt to resolve SDK versions anymore when downloading from the mirror.
+  Instead of '5.0' Users should now specify the exact version '5.0.0', since
+  '5.0.1' is already API-level 13.
+- Updated the documentation to use '5.0.0' where appropriate.
+
 # v0.1.4 (2024-10-08)
 
 - Fixed a bug introduced in v0.1.3, which caused the action to not set output variables,

--- a/README.md
+++ b/README.md
@@ -24,18 +24,18 @@ jobs:
 
 **inputs**:
 
-| Name       | Type    | Default | Description                                                                                                                |
-|------------|---------|---------|----------------------------------------------------------------------------------------------------------------------------|
-| version    | String  | 4.1     | Version of the OpenHarmony SDK (e.g. `4.0`, `4.1` or `5.0`)                                                                |
-| cache      | Boolean | true    | Uses the GitHub actions cache to cache the SDK when enabled.                                                               |
-| components | String  | all     | SDK components that should be added. `all` or semicolon seperated list of components.                                      |
-| mirror     | Boolean | true    | Download from Github Releases mirror of the SDK if possible.                                                               |
+| Name       | Type    | Default | Description                                                                           |
+|------------|---------|---------|---------------------------------------------------------------------------------------|
+| version    | String  | 5.0.0   | Version of the OpenHarmony SDK (e.g. `4.0`, `4.1`, `5.0.0` or `5.0.1`)                |
+| cache      | Boolean | true    | Uses the GitHub actions cache to cache the SDK when enabled.                          |
+| components | String  | all     | SDK components that should be added. `all` or semicolon seperated list of components. |
+| mirror     | Boolean | true    | Download from Github Releases mirror of the SDK if possible.                          |
 
 **outputs**:
 
 
-| Name            | Type   | Description                                            |
-|-----------------|--------|--------------------------------------------------------|
-| api-version     | String | API Version of the SDK (e.g. `12` for OpenHarmony 5.0) |
-| sdk-version     | String | Specific SDK version (e.g. `4.1.7.5`)                  |
-| ohos_sdk_native | String | Path to the `native` directory in the OpenHarmony SDK. |
+| Name            | Type   | Description                                                                             |
+|-----------------|--------|-----------------------------------------------------------------------------------------|
+| api-version     | String | API Version of the SDK (e.g. `12` for OpenHarmony 5.0.0, or `13` for OpenHarmony 5.0.1) |
+| sdk-version     | String | Specific SDK version (e.g. `4.1.7.5`)                                                   |
+| ohos_sdk_native | String | Path to the `native` directory in the OpenHarmony SDK.                                  |

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: 'OpenHarmony SDK release version'
     required: false
-    default: '4.1'
+    default: '5.0.0'
   cache:
     description: "Whether to cache the SDK or not"
     required: false


### PR DESCRIPTION
To add OH 5.0.1 to the SDK mirror, we need to make a breaking change, otherwise users specifying
5.0 would get auto-updated to 5.0.1, which is a
newer API version and would thus likely break
them.