### PR TITLE
Use 'unzip -q' to avoid large logs

### DIFF
--- a/install_ohos_sdk.sh
+++ b/install_ohos_sdk.sh
@@ -52,7 +52,7 @@ function extract_sdk_components() {
         echo "::group::Unzipping archive"
         #shellcheck disable=SC2144
         if [[ -f "${COMPONENT}" ]]; then
-          unzip "${COMPONENT}"
+          unzip -q "${COMPONENT}"
         else
           echo "Failed to find component ${COMPONENT}"
           ls -la


### PR DESCRIPTION
For #26 

Ship this with the next release. 