### PR TITLE
Pin nested cache action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
       run: echo "Cache ${{ inputs.cache }}, version ${{ inputs.version }}, components ${{ inputs.components }}, fixup ${{ inputs.fixup-path }}"
     - name: Cache SDK
       id: cache
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: ~/setup-ohos-sdk
         key: "v1-${{ runner.os }}-ohos-sdk-${{ inputs.version }}-${{ inputs.components }}-${{ inputs.fixup-path }}"


### PR DESCRIPTION
Here I pin the nested cache action so this action can be used in repos that require actions to be pinned to a commit SHA.

https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/

This SHA is v5.0.5: https://github.com/actions/cache/commit/27d5ce7f107fe9357f9df03efb73ab90386fccae